### PR TITLE
fix: Always execute aborts when setting and unsetting of a busy flag …

### DIFF
--- a/fs/fs_zenfs.h
+++ b/fs/fs_zenfs.h
@@ -87,7 +87,11 @@ class ZenMetaLog {
     read_pos_ = zone->start_;
   }
 
-  virtual ~ZenMetaLog() { assert(zone_->UnsetBusy()); }
+  virtual ~ZenMetaLog() {
+    // TODO: report async error status
+    auto ret = zone_->UnsetBusy();
+    assert(ret);
+  }
 
   IOStatus AddRecord(const Slice& slice);
   IOStatus ReadRecord(Slice* record, std::string* scratch);

--- a/fs/zbd_zenfs.h
+++ b/fs/zbd_zenfs.h
@@ -107,8 +107,9 @@ class ZonedBlockDevice {
 
   Zone *GetIOZone(uint64_t offset);
 
-  Zone *AllocateZone(Env::WriteLifeTimeHint lifetime);
-  Zone *AllocateMetaZone();
+  IOStatus AllocateZone(std::shared_ptr<Zone *> out_zone,
+                        Env::WriteLifeTimeHint lifetime);
+  IOStatus AllocateMetaZone(std::shared_ptr<Zone *> out_meta_zone);
 
   uint64_t GetFreeSpace();
   uint64_t GetUsedSpace();
@@ -117,7 +118,7 @@ class ZonedBlockDevice {
   std::string GetFilename();
   uint32_t GetBlockSize();
 
-  void ResetUnusedIOZones();
+  Status ResetUnusedIOZones();
   void LogZoneStats();
   void LogZoneUsage();
 
@@ -140,6 +141,7 @@ class ZonedBlockDevice {
 
  private:
   std::string ErrorToString(int err);
+  inline IOStatus UnsetBusyAndLogError(Zone *zone);
 };
 
 }  // namespace ROCKSDB_NAMESPACE


### PR DESCRIPTION
…fails.

The setting and unsetting of busy flags within `assert` causes bugs in
non-debug builds because the content of the asserts is not executed.

Introduced `assert_always` that executes an abort if the expression is false
also in non-debug builds.

Reported-by: Hans Holmberg <hans.holmberg@wdc.com>
Suggested-by: Andreas Hindborg <andreas.hindborg@wdc.com>
Signed-off-by: Dennis Maisenbacher <dennis.maisenbacher@wdc.com>